### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project provides a Model Context Protocol (MCP) server that connects AI assistants to external data sources (Google, Bing, etc.) via [SearchAPI.site](https://searchapi.site). 
 
+<a href="https://glama.ai/mcp/servers/@mrgoonie/searchapi-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mrgoonie/searchapi-mcp-server/badge" alt="SearchAPI Server MCP server" />
+</a>
+
 ## SearchAPI.site
 
 - [Website](https://searchapi.site)


### PR DESCRIPTION
This PR adds a badge for the [SearchAPI MCP Server](https://glama.ai/mcp/servers/@mrgoonie/searchapi-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mrgoonie/searchapi-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mrgoonie/searchapi-mcp-server/badge" alt="SearchAPI Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.